### PR TITLE
Role checks and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Role Variables
 --------------
 See [defaults/main.yml](defaults/main.yml).
 
+There are two ways to install:
+1. With a HTCondor [role](https://htcondor.readthedocs.io/en/latest/getting-htcondor/admin-quick-start.html#the-three-roles) (ONE of `central-manager`, `submit` or `execute`)  
+
+2.  Without role: set `condor_role: ""`  
+:warning: This will **not remove** previously defined roles in the configuration.
+
+This role always tries to update HTCondor to the newest version, if the installed version is older than `condor_minimal_version`. If that update failed and the version is still below the specified minimum, it will reinstall HTCondor with the getCondor script and automatically fetch the newest available version.
+
+`condor_enforce_role: true` will skip the updating step and reinstall the specified role, if it is not already present.
+If set to `false` HTCondor and the role will only be installed if HTCondor is not installed.
+
 Installation
 ------------
 
@@ -26,6 +37,7 @@ Playbook usage example
   vars:
     condor_fs_domain: my_own_string
     condor_uid_domain: my_own_string
+    condor_enforce_role: false
   roles:
     - usegalaxy_eu.htcondor
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,7 +49,7 @@ condor_extra: |
 #condor_role: central-manager
 condor_role: execute
 
-condor_host_address: example.org
+condor_host: example.org
 
 condor_password: IForgotToChangeMyPassword:/
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,9 @@ condor_extra: |
 # condor_role: central-manager
 condor_role: execute
 
+# reinstalls condor with role and newest version if true
+condor_enforce_role: false
+
 condor_host: example.org
 
 condor_password: IForgotToChangeMyPassword:/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,8 +45,8 @@ condor_extra: |
     # UPDATE_INTERVAL = 300
 
 
-#condor_role: submit
-#condor_role: central-manager
+# condor_role: submit
+# condor_role: central-manager
 condor_role: execute
 
 condor_host: example.org
@@ -64,5 +64,6 @@ condor_system_periodic_remove: "{{ 7 * 24 * 60 * 60}}"
 condor_fs_domain: put_here_your_string
 condor_uid_domain: put_here_your_string
 
-# Specify a version number, as returned in condor_version command. It will update automatically to the NEWEST version if the installed condor version is lower
+# Specify a version number, as returned in condor_version command.
+# It will update automatically to the NEWEST version if the installed condor version is lower
 condor_minimal_version: 10.2.0

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,4 +3,3 @@
   ansible.builtin.service:
     name: condor
     state: reloaded
-  when: ansible_facts.services['condor.service'].state == 'running'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,6 +5,7 @@ galaxy_info:
   company: Galaxy Europe
   license: GPL-3.0
   min_ansible_version: 2.11
+  namespace: usegalaxy_eu
   role_name: htcondor
   platforms:
     - name: EL

--- a/tasks/check_roles.yml
+++ b/tasks/check_roles.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test if manager role is present
-  ansible.builtin.shell: grep -nr "use role:get_htcondor_central_manager" /etc/condor/config.d
+  ansible.builtin.command: grep -nr "use role:get_htcondor_central_manager" /etc/condor/config.d
   register: manager
   failed_when: "manager.rc == 2"
   ignore_errors: true
@@ -14,7 +14,7 @@
   when: manager.rc == 1
 
 - name: Test if submit role is present
-  ansible.builtin.shell: grep -nr "use role:get_htcondor_submit" /etc/condor/config.d
+  ansible.builtin.command: grep -nr "use role:get_htcondor_submit" /etc/condor/config.d
   register: submit
   failed_when: "submit.rc == 2"
   ignore_errors: true
@@ -28,7 +28,7 @@
   when: submit.rc == 1
 
 - name: Test if execute role is present
-  ansible.builtin.shell: grep -nr "use role:get_htcondor_execute" /etc/condor/config.d
+  ansible.builtin.command: grep -nr "use role:get_htcondor_execute" /etc/condor/config.d
   register: execute
   failed_when: "execute.rc == 2"
   ignore_errors: true

--- a/tasks/check_roles.yml
+++ b/tasks/check_roles.yml
@@ -1,0 +1,42 @@
+---
+- name: Test if manager role is present
+  ansible.builtin.shell: grep -nr "use role:get_htcondor_central_manager" /etc/condor/config.d
+  register: manager
+  failed_when: "manager.rc == 2"
+  ignore_errors: true
+
+- debug:
+    msg: "Central manager role installed."
+  when: manager.stdout | length > 0
+
+- debug:
+    msg: "Central manager role not installed."
+  when: manager.rc == 1
+
+- name: Test if submit role is present
+  ansible.builtin.shell: grep -nr "use role:get_htcondor_submit" /etc/condor/config.d
+  register: submit
+  failed_when: "submit.rc == 2"
+  ignore_errors: true
+
+- debug:
+    msg: "Submit role installed."
+  when: submit.stdout | length > 0
+
+- debug:
+    msg: "Submit role not installed."
+  when: submit.rc == 1
+
+- name: Test if execute role is present
+  ansible.builtin.shell: grep -nr "use role:get_htcondor_execute" /etc/condor/config.d
+  register: execute
+  failed_when: "execute.rc == 2"
+  ignore_errors: true
+
+- debug:
+    msg: "Execute role installed."
+  when: execute.stdout | length > 0
+
+- debug:
+    msg: "Execute role not installed."
+  when: execute.rc == 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,11 @@
   include_tasks: check_roles.yml
 
 - name: Check for existing HTCondor installation
-  ansible.builtin.shell: /usr/bin/condor_version | head -n 1 | cut -d ' ' -f2
+  ansible.builtin.shell: |
+    set -o pipefail #
+    /usr/bin/condor_version | head -n 1 | cut -d ' ' -f2
   register: condor_installed_version
+  ignore_errors: true
 
 - name: Set old version
   ansible.builtin.set_fact:
@@ -60,7 +63,7 @@
 
   when: >
     (not condor_installed_version.stdout) or (old_version | bool) or ((condor_enforce_role | bool) and
-    (condor_role == 'central-manager' and (manager.rc >= 1)) or 
+    (condor_role == 'central-manager' and (manager.rc >= 1)) or
     (condor_role == 'submit' and (submit.rc >= 1)) or
     (condor_role == 'execute' and (execute.rc >= 1)))
 # Reinstalling oly if version outdated or role not found and role is enforced

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,8 +8,21 @@
     var: condor_installed_version.stdout
 
 - name: Condor install
-  ansible.builtin.shell: curl -fsSL https://get.htcondor.org | sudo /bin/bash -s -- --no-dry-run
-  when: condor_installed_version.stdout <= condor_minimal_version
+  block:
+
+    - name: Install without role
+      ansible.builtin.shell: curl -fsSL https://get.htcondor.org | sudo /bin/bash -s -- --no-dry-run
+      when: (condor_installed_version.stdout <= condor_minimal_version) and not \
+       (condor_role == 'submit' or condor_role == 'execute' or condor_role == 'central_manager')
+
+    - name: Install with role
+      ansible.builtin.shell: |
+        curl -fsSL https://get.htcondor.org | \
+        sudo GET_HTCONDOR_PASSWORD={{ condor_password }} \
+        /bin/bash -s -- --no-dry-run --{{ condor_role }} {{ condor_host }}
+      when: (condor_installed_version.stdout <= condor_minimal_version) and \
+       (condor_role == 'submit' or condor_role == 'execute' or condor_role == 'central_manager')
+
 
 - name: Require local config
   lineinfile:
@@ -34,9 +47,6 @@
     src: meta_walltime.py
     mode: 0755
   notify: reload condor
-
-- name: Populate service facts
-  service_facts:
 
 - name: enable and stop condor
   ansible.builtin.service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,34 +1,76 @@
 ---
+- name: Include role check
+  include_tasks: check_roles.yml
+
 - name: Check for existing HTCondor installation
   ansible.builtin.shell: /usr/bin/condor_version | head -n 1 | cut -d ' ' -f2
   register: condor_installed_version
+
+- name: Set old version
+  ansible.builtin.set_fact:
+    old_version: false
 
 - name: Print HTCondor version
   ansible.builtin.debug:
     var: condor_installed_version.stdout
 
+- name: Try to update
+  block:
+    - name: Check if version is older than minimal
+      ansible.builtin.set_fact:
+        old_version: true
+      when: (condor_installed_version.stdout is version(condor_minimal_version, '<'))
+
+    - name: Try to update condor
+      package:
+        name: condor
+        state: latest
+      when: old_version | bool
+
+    - name: Check again for existing HTCondor version
+      ansible.builtin.shell: /usr/bin/condor_version | head -n 1 | cut -d ' ' -f2
+      register: condor_installed_version2
+
+    - name: Check again if version is older than minimal
+      ansible.builtin.set_fact:
+        old_version: false
+      when: (condor_installed_version2.stdout is version(condor_minimal_version, '>='))
+
+  when: condor_installed_version.stdout and (not condor_enforce_role | bool)
+
 - name: Condor install
   block:
+    - name: Remove previous installation
+      package:
+        name: condor
+        state: absent
 
     - name: Install without role
       ansible.builtin.shell: curl -fsSL https://get.htcondor.org | sudo /bin/bash -s -- --no-dry-run
-      when: (condor_installed_version.stdout <= condor_minimal_version) and not \
-       (condor_role == 'submit' or condor_role == 'execute' or condor_role == 'central_manager')
+      when: >
+        not (condor_role == 'submit' or condor_role == 'execute' or condor_role == 'central-manager')
 
     - name: Install with role
       ansible.builtin.shell: |
         curl -fsSL https://get.htcondor.org | \
         sudo GET_HTCONDOR_PASSWORD={{ condor_password }} \
         /bin/bash -s -- --no-dry-run --{{ condor_role }} {{ condor_host }}
-      when: (condor_installed_version.stdout <= condor_minimal_version) and \
-       (condor_role == 'submit' or condor_role == 'execute' or condor_role == 'central_manager')
+      when: >
+        (condor_role == 'submit' or condor_role == 'execute' or condor_role == 'central-manager')
 
+  when: >
+    (not condor_installed_version.stdout) or (old_version | bool) or ((condor_enforce_role | bool) and
+    (condor_role == 'central-manager' and (manager.rc >= 1)) or 
+    (condor_role == 'submit' and (submit.rc >= 1)) or
+    (condor_role == 'execute' and (execute.rc >= 1)))
+# Reinstalling oly if version outdated or role not found and role is enforced
 
 - name: Require local config
   lineinfile:
     dest: /etc/condor/condor_config
-    line: 'REQUIRE_LOCAL_CONFIG_FILE = true'
-    regexp: '^ *REQUIRE_LOCAL_CONFIG_FILE.*'
+    line: "REQUIRE_LOCAL_CONFIG_FILE = true"
+    regexp: "^ *REQUIRE_LOCAL_CONFIG_FILE.*"
+  when: condor_copy_template | bool
   notify: reload condor
 
 - name: Copy local config

--- a/templates/condor_config.j2
+++ b/templates/condor_config.j2
@@ -29,7 +29,9 @@ SYSTEM_PERIODIC_REMOVE = \
   (JobStatus == 5 && time() - EnteredCurrentStatus > {{ condor_system_periodic_remove }})
 {% endif %}
 
+{% if condor_network_interface is defined %}
 NETWORK_INTERFACE = {{ condor_network_interface }}
+{% endif %}
 
 {% if condor_extra %}
 {{ condor_extra }}


### PR DESCRIPTION
- Users can define a role, if that role and `condor_enforce_role` is defined, condor will be reinstalled if the role is missing
- without a role defined, it will just install or try to update condor to the minimal required version
- without `condor_enforce_role` the role will only be installed, if the update to the `condor_minimal_version` version was not successful or condor was missing at all.