### PR TITLE
Run Ansible Lint on GitHub Actions

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,5 @@
+---
+kinds:
+  - vars: "**/molecule/*/vars.yml"
+exclude_paths:
+  - .github/

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,31 +1,36 @@
 ---
-name: CI
-'on':
+name: Code style
+
+"on":
   pull_request:
   push:
     branches:
       - main
 
-defaults:
-  run:
-    working-directory: 'usegalaxy_eu.htcondor'
-
 jobs:
-  lint:
-    name: Lint
+  ansible-lint:
+    name: Ansible Lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v2
-        with:
-          path: 'usegalaxy_eu.htcondor'
+        uses: actions/checkout@v3
+
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint-action@v6
+
+  yamllint:
+    name: YAML Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
 
-      - name: Install test dependencies.
+      - name: Install yamllint.
         run: pip3 install yamllint
 
       - name: Lint code.


### PR DESCRIPTION
- Add ansible-lint job to the "CI" GitHub workflow.
- Rename the "lint" job to "yamllint".
- Rename the "CI" GitHub workflow to "Code style". Rename also the workflow definition file to style.yml.